### PR TITLE
Edit desktop entry to comply with Linux standards - Fixes #25

### DIFF
--- a/svgcleaner.desktop
+++ b/svgcleaner.desktop
@@ -3,6 +3,6 @@ Name=SVG Cleaner
 GenericName=SVG Cleaning Program
 Comment=Batch, tunable, crossplatform SVG cleaning program
 Exec=svgcleaner-gui
-Icon=/usr/share/icons/hicolor/scalable/apps/svgcleaner.svg
+Icon=svgcleaner
 Type=Application
 Categories=Qt;Graphics;


### PR DESCRIPTION
Edited [svgcleaner.desktop][desktop] to comply with the Linux standard - [freedesktop desktop entry specs][freedesktop] and to ensure **compatibility with icon themes**. The following hardcoded icon path was removed:

    Icon=/usr/share/icons/hicolor/scalable/apps/svgcleaner.svg

and replaced with the correct one:

    Icon=svgcleaner

It may seem like just a cosmetic change, but standards compliance contributes to quality of the app. :bowtie:

  [desktop]: https://github.com/RazrFalcon/SVGCleaner/blob/master/svgcleaner.desktop "SVGCleaner's desktop entry"
  [freedesktop]: http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys "Link to Freedesktop Desktop Entry Specification"