### PR TITLE
Fix missing LC_ALL error by including locale.h

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -21,6 +21,7 @@
 
 #include <QDir>
 #include <QtDebug>
+#include <locale.h>
 
 #ifdef USE_IPC
 #include <QSharedMemory>


### PR DESCRIPTION
Fixes error compiling on OS X El Capitan:
`main.cpp:358:15: error: use of undeclared identifier 'LC_ALL'
    setlocale(LC_ALL, "");`
![screen shot 2016-02-16 at 11 41 25 am](https://cloud.githubusercontent.com/assets/967800/13088710/397609ac-d4a2-11e5-9c8f-3775cce09ea5.png)
