### PR TITLE
Stop removing matrix spaces which cause rendering issues.

### DIFF
--- a/src/cli/transform.cpp
+++ b/src/cli/transform.cpp
@@ -278,18 +278,9 @@ QString TransformPrivate::simplified() const
     }
 
     transform += QL1S("(");
-    bool isTrim = Keys::get().flag(Key::RemoveUnneededSymbols);
     for (int i = 0; i < newPoints.size(); ++i) {
         if (i != 0) {
-            if (isTrim) {
-                if ( newPoints.at(i).startsWith(QL1C('.'))
-                        || newPoints.at(i).at(0).isDigit()
-                        || newPoints.at(i).startsWith(QL1C('-'))
-                      )
-                    transform += QL1S(" ");
-            } else {
-                transform +=QL1S(" ");
-            }
+              transform +=QL1S(" ");
         }
         transform += newPoints.at(i);
     }

--- a/src/cli/transform.cpp
+++ b/src/cli/transform.cpp
@@ -282,9 +282,10 @@ QString TransformPrivate::simplified() const
     for (int i = 0; i < newPoints.size(); ++i) {
         if (i != 0) {
             if (isTrim) {
-                if ((!newPoints.at(i-1).contains(QL1C('.'))
-                     && newPoints.at(i).startsWith(QL1C('.')))
-                        || newPoints.at(i).at(0).isDigit())
+                if ( newPoints.at(i).startsWith(QL1C('.'))
+                        || newPoints.at(i).at(0).isDigit()
+                        || newPoints.at(i).startsWith(QL1C('-'))
+                      )
                     transform += QL1S(" ");
             } else {
                 transform +=QL1S(" ");


### PR DESCRIPTION
Currently `matrix(0.7071 -0.7071 0.7071 0.7071 -21.2903 51.4014)` gets turned into:
`matrix(.7071-.7071.7071.7071-21.29 51.4)`
With this patch it will now turn into: `matrix(.7071 -.7071 .7071 .7071 -21.29 51.4)`

Most SVG renderers are fine with the current output, including Chrome, Apple Preview, etc. However, some like Adobe Illustrator (tested latest CC 2015) completely mess this up and make the cleaned SVGs look terrible.

Right now stripping the spaces is controllable with the flag `--remove-unneeded-symbols`. Enabling this flag disables a couple of other symbol removals however, so I figured I'd contribute a patch.

Currently a space is added if any of the following conditions are met:
* The next matrix point starts with a `.` and the previous point didn't contain a `.`
* The next matrix matrix point starts with a number

My patch changes this so that a space is added if any of the following conditions are met:
* The next matrix point starts with a `.`
* The next matrix point starts with a number
* The next matrix point starts with a `-`

Illustrator will mess up the matrix transform when a matrix transform that starts with a `-` or a `.` is not separated by a space.

In changing these conditions I feel that maybe this makes it so that a space is always added now? I'm not familiar with the SVG spec

**Edit: New commit added for cleaner code if that is the case.**


Screenshot:
![matrix transform patch example](https://cloud.githubusercontent.com/assets/967800/13089107/febd382e-d4a3-11e5-8948-e80baead7d84.png)

The two SVGs included in the screenshot:
[SVG Comparison.zip](https://github.com/RazrFalcon/SVGCleaner/files/133175/SVG.Comparison.zip)



