### PR TITLE
Add --stdout option / redirect error messages to stderr

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -13,6 +13,7 @@ EXAMPLE:
 FLAGS:
     -h, --help                               Prints help information
     -V, --version                            Prints version information
+    -c, --stdout                             Prints result as standard output
 
 OPTIONS:
 Elements:

--- a/src/cleaner.rs
+++ b/src/cleaner.rs
@@ -205,6 +205,10 @@ pub fn write_buffer(doc: &Document, opt: &WriteOptions, buf: &mut Vec<u8>) {
     doc.write_buf_opt(opt, buf);
 }
 
+pub fn write_stdout(data: &[u8]) -> Result<usize, io::Error> {
+    io::stdout().write(&data)
+}
+
 pub fn save_file(data: &[u8], path: &str) -> Result<(), io::Error> {
     let mut f = fs::File::create(&path)?;
     f.write_all(&data)?;


### PR DESCRIPTION
Hi,

I added an option to take output to stdout. This is my first attempt to write Rust code other than hello world, so I believe it could be not-so-much-idiomatic ;) Please take your time to tell me if there's anything to fix!

Also, I redirected error messages to stderr to prevent error messages to be written to stdout. I needed this option because I wanted to replace svgo with svgcleaner, using stream interface in Node.