### PR TITLE
Pass --disable-embed-rasters to scour

### DIFF
--- a/tools/stats/src/main.rs
+++ b/tools/stats/src/main.rs
@@ -348,6 +348,7 @@ fn clean_with_scour(exe_path: &str, in_path: &str, out_path: &str) -> bool {
         .arg("--remove-titles")
         .arg("--remove-descriptions")
         .arg("--remove-metadata")
+        .arg("--disable-embed-rasters")
         .output();
 
     match res {


### PR DESCRIPTION
By default, scour embeds raster images (e.g. referenced PNG images) into the SVG image to make the SVG stand-alone.  Unsurprisingly, this tend to make images larger than they were before regardless of how well the SVG cleaner actually work.