### PR TITLE
Don't fail if we can't resolve currentColor

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@ error_chain! {
 
     errors {
         UnresolvedAttribute(attr_name: String) {
-            display("failed to resolved attribute '{}'", attr_name)
+            display("failed to resolve attribute '{}'", attr_name)
         }
 
         MissingAttribute(tag_name: String, attr_name: String) {

--- a/src/task/resolve_inherit.rs
+++ b/src/task/resolve_inherit.rs
@@ -65,7 +65,9 @@ pub fn resolve_inherit(doc: &Document) -> Result<()> {
             if let Some(av) = av {
                 node.set_attribute((*id, av.clone()));
             } else {
-                resolve_impl(&mut node, *id, AttributeId::Color)?;
+                // We don't care if this doesn't resolve, the color will still be `currentColor` if
+                // we can't find it in the document.
+                let _ = resolve_impl(&mut node, *id, AttributeId::Color);
             }
         }
     }
@@ -169,6 +171,16 @@ mod tests {
 </svg>",
 "<svg color='#ff0000'>
     <rect fill='#ff0000' stroke='#ff0000'/>
+</svg>
+");
+
+    test!(current_color_4,
+"<svg>
+    <rect fill='currentColor' stroke='currentColor'/>
+</svg>
+",
+"<svg>
+    <rect fill='currentColor' stroke='currentColor'/>
 </svg>
 ");
 


### PR DESCRIPTION
#205 

Some programs (like `gnuplot`) use the `currentColor` value without defining it. This also may be needed for the `inherit` value, which will fail for the same reason if there is not a value in a parent to inherit. 

The code change also has the smell of ignoring an error result. Was this error by design? Is this a bug for `gnuplot` generating invalid svg?